### PR TITLE
Add clean to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 cd ./model/networks/block_extractor
-python setup.py install --user
+python setup.py clean --all install --user
 
 cd ..
 cd local_attn_reshape
-python setup.py install --user
+python setup.py clean --all install --user
 
 cd ..
 cd resample2d_package
-python setup.py install --user
+python setup.py clean --all install --user


### PR DESCRIPTION
In case user messes up the first install, adding the `clean --all` in the setup command will ensure a clean build each time.